### PR TITLE
Add Editor.js integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@editorjs/editorjs": "^2.30.8",
+        "@editorjs/header": "^2.8.8",
+        "@editorjs/list": "^2.0.8",
         "cors": "^2.8.5",
+        "editorjs-html": "^4.0.5",
         "express": "^4.21.2",
         "quill": "^2.0.3"
       },
@@ -597,6 +601,43 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@codexteam/icons": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.0.5.tgz",
+      "integrity": "sha512-s6H2KXhLz2rgbMZSkRm8dsMJvyUNZsEjxobBEg9ztdrb1B2H3pEzY6iTwI4XUPJWJ3c3qRKwV4TrO3J5jUdoQA==",
+      "license": "MIT"
+    },
+    "node_modules/@editorjs/editorjs": {
+      "version": "2.30.8",
+      "resolved": "https://registry.npmjs.org/@editorjs/editorjs/-/editorjs-2.30.8.tgz",
+      "integrity": "sha512-ClFuxI1qZTfXPJTacQfsJtOUP6bKoIe6BQNdAvGsDTDVwMnZEzoaSOwvUpdZEE56xppVfQueNK/1MElV9SJKHg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@editorjs/header": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/@editorjs/header/-/header-2.8.8.tgz",
+      "integrity": "sha512-bsMSs34u2hoi0UBuRoc5EGWXIFzJiwYgkFUYQGVm63y5FU+s8zPBmVx5Ip2sw1xgs0fqfDROqmteMvvmbCy62w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codexteam/icons": "^0.0.5",
+        "@editorjs/editorjs": "^2.29.1"
+      }
+    },
+    "node_modules/@editorjs/list": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@editorjs/list/-/list-2.0.8.tgz",
+      "integrity": "sha512-/EJNvpeJYa1YDtYa85ug9R3sbDyI5ZlMHQ2bIh5S9iPa19qXe45jk6kgcew+jMNQq3j4NS4Q6YeeFbU1QkNMWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codexteam/icons": "^0.3.2"
+      }
+    },
+    "node_modules/@editorjs/list/node_modules/@codexteam/icons": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.3.3.tgz",
+      "integrity": "sha512-cp7mkZPgmBuSxigTm3Vb+DtVHYeX7qXfQd7o05vcLD8Ag5WvRlol2QSn5P10k0CDAJwmkH9nQGQLBycErS9lsQ==",
       "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -4039,6 +4080,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/editorjs-html": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/editorjs-html/-/editorjs-html-4.0.5.tgz",
+      "integrity": "sha512-ImQYxB3fNCJcd+nJ+Vbne/6PxidO1cYByNpu9nBDStVabfjVrMW65BuR+IEZfOii8VKYH+CW/lYDb2GDlzZtDg==",
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,17 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@editorjs/editorjs": "^2.30.8",
+    "@editorjs/header": "^2.8.8",
+    "@editorjs/list": "^2.0.8",
     "cors": "^2.8.5",
+    "editorjs-html": "^4.0.5",
     "express": "^4.21.2",
     "quill": "^2.0.3"
   },
   "devDependencies": {
-    "parcel": "^2.13.2",
     "jest": "^29.7.0",
+    "parcel": "^2.13.2",
     "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- swap Quill editor for Editor.js on the frontend
- store editor data as JSON and render using `editorjs-html`
- add Editor.js packages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875095772f083289d82596433ad7e01