### PR TITLE
Enable inline editing of notes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -92,3 +92,10 @@ body {
     border: 1px solid #ccc;
     padding: 10px;
   }
+
+  .inline-editor {
+    height: 200px;
+    border: 1px solid #ccc;
+    margin-top: 10px;
+    padding: 10px;
+  }


### PR DESCRIPTION
## Summary
- add inline editing functionality to `app.js`
- parse HTML note content into EditorJS format
- allow editing a note by clicking its card
- style inline editors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68750fa9d824832883e35bbeb0b1726e